### PR TITLE
Fix spacing between labels and values

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -57,7 +57,7 @@ export function Analytics() {
 
                 <div className="w-full max-w-[160px] mt-10 space-y-3">
                     <div className="flex justify-between font-pixel text-[6px] text-[var(--color-red)]">
-                        <span>CORRUPTION</span>
+                        <span>CORRUPTION - </span>
                         <span>{Math.round(bossHpPercent)}%</span>
                     </div>
                     <div className="rpg-bar h-2 border-black/60 bg-black">
@@ -85,14 +85,14 @@ export function Analytics() {
                             <div className="space-y-6">
                                 <div className="space-y-2">
                                     <div className="flex justify-between font-pixel text-[8px] text-[var(--text-muted)]">
-                                        <span>CURRENT STRENGTH</span>
-                                        <span className="text-white">{totalTimeDebt.toFixed(2)}h</span>
+                                        <span>CURRENT STRENGTH: </span>
+                                        <span className="text-white">{totalTimeDebt.toFixed(2)} h</span>
                                     </div>
                                     <div className="h-1 bg-gray-800 w-full" />
                                 </div>
                                 <div className="space-y-2">
                                     <div className="flex justify-between font-pixel text-[8px] text-[var(--text-muted)]">
-                                        <span>CORRUPTION RATE</span>
+                                        <span>CORRUPTION RATE: </span>
                                         <span className="text-[var(--color-red)]">0.05% / CYCLE</span>
                                     </div>
                                     <div className="h-1 bg-gray-800 w-full" />

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -40,7 +40,7 @@ export function Dashboard() {
                     <div className="pixel-box bg-[var(--bg-card)] p-8 space-y-8">
                         <div className="space-y-4">
                             <div className="flex justify-between font-pixel text-[10px]">
-                                <span>LIFE CAPACITY (HEALTH)</span>
+                                <span>LIFE CAPACITY (HEALTH): </span>
                                 <span>{Math.round(healthPercent)}%</span>
                             </div>
                             <div className="rpg-bar h-6 border-4 border-black">
@@ -50,7 +50,7 @@ export function Dashboard() {
                                     transition={{ type: 'spring', damping: 20 }}
                                 />
                                 <div className="absolute inset-0 flex items-center justify-center font-pixel text-[8px] text-white drop-shadow-md">
-                                    DEBT: {totalTimeDebt.toFixed(2)}h
+                                    DEBT: {totalTimeDebt.toFixed(2)} h
                                 </div>
                             </div>
                         </div>
@@ -58,7 +58,7 @@ export function Dashboard() {
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                             <div className="space-y-4">
                                 <div className="flex justify-between font-pixel text-[8px] text-[var(--text-muted)]">
-                                    <span>EXPERIENCE</span>
+                                    <span>EXPERIENCE: </span>
                                     <span>{futureHealthScore}/100</span>
                                 </div>
                                 <div className="rpg-bar h-4">
@@ -71,8 +71,8 @@ export function Dashboard() {
 
                             <div className="space-y-4">
                                 <div className="flex justify-between font-pixel text-[8px] text-[var(--text-muted)]">
-                                    <span>MANA</span>
-                                    <span>{availableTimeToday.toFixed(2)}h</span>
+                                    <span>MANA: </span>
+                                    <span>{availableTimeToday.toFixed(2)} h</span>
                                 </div>
                                 <div className="rpg-bar h-4">
                                     <motion.div

--- a/src/pages/Quests.tsx
+++ b/src/pages/Quests.tsx
@@ -98,9 +98,9 @@ export function Quests() {
                 <div className="pixel-box bg-[var(--bg-card)] mt-12 p-8">
                     <label className="flex items-center justify-between mb-8 font-pixel text-[10px]">
                         <span className="flex items-center gap-2">
-                            <Clock className="w-4 h-4" /> QUEST DURATION
+                            <Clock className="w-4 h-4" /> QUEST DURATION:
                         </span>
-                        <span className="text-[var(--color-yellow)] font-pixel text-lg">{duration}H</span>
+                        <span className="text-[var(--color-yellow)] font-pixel text-lg"> {duration} H </span>
                     </label>
                     <input
                         type="range"


### PR DESCRIPTION
This PR improves UI readability by fixing missing spacing and minor formatting issues between text labels and their corresponding values across multiple screens.
Changes-
Added explicit spacing between labels and values in:
Dashboard.tsx
Analytics.tsx
Quests.tsx
Adjusted minor punctuation (colons) where necessary to maintain consistent visual formatting.

Why
Previously, several stats were rendered without proper spacing (e.g. 12.5h, XP100), which reduced readability and visual clarity. This update ensures values are clearly separated from labels for a cleaner and more polished UI.

Scope-
UI-only change
No logic or state management affected
No functional behavior changed

before-
<img width="1910" height="1025" alt="Screenshot 2026-02-05 000858" src="https://github.com/user-attachments/assets/444ef188-159a-4799-a1c2-d0d450049e24" />
<img width="1919" height="1022" alt="Screenshot 2026-02-05 000914" src="https://github.com/user-attachments/assets/3bb14b46-ff13-4101-9fd3-8d6c6bcfbb2f" />
<img width="1919" height="1077" alt="Screenshot 2026-02-05 000936" src="https://github.com/user-attachments/assets/111ad059-96e5-4e11-9aa7-dbf26a258cdd" />

After-

<img width="1910" height="1076" alt="Screenshot 2026-02-05 092245" src="https://github.com/user-attachments/assets/271fb0fb-1b82-4ada-8847-de713e11484e" />
<img width="1895" height="1033" alt="Screenshot 2026-02-05 092310" src="https://github.com/user-attachments/assets/3dfcd48a-a3cf-4ee0-98e3-aa2a0ea2d759" />
<img width="1900" height="1040" alt="Screenshot 2026-02-05 092330" src="https://github.com/user-attachments/assets/3fe41602-be89-4369-b9b9-0013fe8d48f8" />


Signed off by: Aaryaveer Mishra <mishraaaryaveer@gmail.com>